### PR TITLE
Integrando o filtro CircuitBreaker com resilience4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ ext {
 
 dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/polarbookshop/edgeservice/web/WebEndpoints.java
+++ b/src/main/java/com/polarbookshop/edgeservice/web/WebEndpoints.java
@@ -1,0 +1,23 @@
+package com.polarbookshop.edgeservice.web;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Configuration
+public class WebEndpoints {
+
+    @Bean
+    public RouterFunction<ServerResponse> routerFunction() {
+        return RouterFunctions.route()
+                .GET("/catalog-fallback", request ->
+                        ServerResponse.ok().body(Mono.just(""), String.class))
+                .POST("/catalog-fallback", request ->
+                        ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).build())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,8 +35,31 @@ spring:
           uri: ${CATALOG_SERVICE_URL:http://localhost:9001}/books
           predicates:
             - Path=/books/**
+          filters:
+            - name: CircuitBreaker
+              args:
+                name: catalogCircuitBreaker
+                fallbackUri: forward:/catalog-fallback
         - id: order-route
           uri: ${ORDER_SERVICE_URL:http://localhost:9002}/orders
           predicates:
             - Path=/orders/**
+          filters:
+              - name: CircuitBreaker
+                args:
+                  name: orderCircuitBreaker
+                  args:
+                    name: orderCircuitBreaker
 
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        slidingWindowSize: 20
+        permittedNumberOfCallsInHalfOpenState: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 15000
+    timelimiter:
+      configs:
+        default:
+          timeoutDuration: 5s


### PR DESCRIPTION
**Integrando o filtro CircuitBreaker com resilience4j nas rotas de solicitação do EgdeService e definindo o routerFunctions para comportamento em caso de fallback ser chamado para solicitações do tipo GET e POST, enquanto o disjuntor estiver no estado ABERTO e configurando as configurações do filtro circuitbreaker, via arquivo application.yml.**