### PR TITLE
Implemento ingress.yml = objeto Ingress para gerenciar e expor as requisições

### DIFF
--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -3,7 +3,7 @@ on: push
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: polarbookshop/edge-service
+  IMAGE_NAME: polar-libraries/edge-service
   VERSION: latest
 
 jobs:

--- a/Tiltfile
+++ b/Tiltfile
@@ -4,6 +4,6 @@ custom_build(
     deps = ['build.gradle', 'src']
 )
 
-k8s_yaml(['k8s/deployment.yml', 'k8s/service.yml'])
+k8s_yaml(['k8s/deployment.yml', 'k8s/service.yml', 'k8s/ingress.yml'])
 
 k8s_resource('edge-service', port_forwards=['9000'])

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: polar-ingress
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: edge-service
+                port:
+                  number: 80


### PR DESCRIPTION
Implemento ingress.yml = objeto Ingress para gerenciar e expor as requisições externas para nosso cluster na porta 80. Agora pode receber requisições sem a necessidade de redirecionar o applicativo com (port forwat), agora ele expoe todo cluster.
