### PR TITLE
kustomize: gerenciamento dos manifestos e geração dinâmica de configMap

### DIFF
--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -45,7 +45,7 @@ jobs:
           kubeval: 0.16.1
           # Different schema required because of https://github.com/instrumenta/kubeval/issues/301
           command: |
-            kubeval --strict --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master -d k8s
+            kustomize build k8s | kubeval --strict --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master -d k8s
   package:
     name: Package and Publish
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -45,7 +45,7 @@ jobs:
           kubeval: 0.16.1
           # Different schema required because of https://github.com/instrumenta/kubeval/issues/301
           command: |
-            kustomize build k8s | kubeval --strict --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master -d k8s
+            kustomize build k8s | kubeval --strict --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master -
   package:
     name: Package and Publish
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/Tiltfile
+++ b/Tiltfile
@@ -6,7 +6,7 @@ custom_build(
 )
 
 # Deploy
-k8s_yaml(['k8s/deployment.yml', 'k8s/service.yml', 'k8s/ingress.yml'])
+k8s_yaml(kustomize('k8s'))
 
 # Manage
 k8s_resource('edge-service', port_forwards=['9000'])

--- a/k8s/application.yml
+++ b/k8s/application.yml
@@ -1,0 +1,9 @@
+spring:
+  redis:
+    host: polar-redis
+  security:
+    oauth2:
+      client:
+        provider:
+          keycloak:
+            issuer-uri: http://polar-keycloak/realms/PolarBookshop

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -35,12 +35,6 @@ spec:
               value: http://order-service
             - name: SPA_URL
               value: http://polar-ui
-            - name: SPRING_CLOUD_CONFIG_URI
-              value: http://config-service
-            - name: SPRING_DATA_REDIS_HOST
-              value: polar-redis
-            - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI
-              value: http://polar-keycloak/realms/PolarBookshop
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
@@ -53,3 +47,10 @@ spec:
               port: 9000
             initialDelaySeconds: 5
             periodSeconds: 15
+          volumeMounts:
+            - name: edge-service-volume
+              mountPath: /workspace/config
+      volumes:
+        - name: edge-config-volume
+          configMap:
+            name: edge-service

--- a/k8s/kustomization.yml
+++ b/k8s/kustomization.yml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yml
+  - service.yml
+  - ingress.yml
+
+configMapGenerator:
+  - name: edge-config
+    files:
+      - application.yml
+    options:
+      labels:
+        app: edge-service

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,9 +11,10 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: 15s
   config:
-    import: "optional:configserver:"
+    import: ""
   cloud:
     config:
+      enabled: false
       uri: http://localhost:8888
       request-connect-timeout: 5000 # 5s
       request-read-timeout: 5000 # 5s


### PR DESCRIPTION
Implementado o Kustomize para gerenciar os manifestos do Kubernetes como uma única entidade através do arquivo kustomization.yml, tornando a gestão mais limpa e otimizada.

Também foi adicionado um ConfigMapGenerator que carrega um arquivo de configuração application.yml. Dessa forma, sempre que houver alterações nesse arquivo, o Kustomize aplica automaticamente as novas configurações e reinicia os pods que o utilizam.

Diferente do ConfigMap criado manualmente, que não refletia alterações mesmo após o restart dos pods, essa abordagem garante que as atualizações sejam aplicadas corretamente de forma automática e declarativa.